### PR TITLE
update: added updating git submodules within west update command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ What just happened:
 
 - ``west update`` clones the other repositories named in the manifest file,
   creating working trees in the installation directory ``zephyrproject``.
+  It also checkouts submodules if cloned projects have defined any.
 
 Use ``west init -m`` to specify another manifest repository. Use ``--mr`` to
 use a revision other than ``master``. Use ``--mf`` to use a manifest file other

--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -867,6 +867,15 @@ class Update(_ProjectCommand):
         self.manifest = Manifest.from_file(topdir=self.topdir,
                                            importer=self.update_importer)
 
+    def update_submodules(self, project, submodules, call_location):
+        # Updates given list of project submodules by using
+        # 'git submodule update --init' command from the location passed
+        # through the call_location parameter value.
+        if submodules:
+            for submodule in submodules:
+                project.git(['-C', call_location, 'submodule', 'update',
+                             '--init', submodule['path']])
+
     def update(self, project):
         if self.args.stats:
             stats = dict()
@@ -931,6 +940,10 @@ class Update(_ProjectCommand):
             if take_stats:
                 stats['checkout new manifest-rev'] = perf_counter() - start
             _post_checkout_help(project, current_branch, sha, is_ancestor)
+
+        # Update project submodules, if it has any.
+        self.update_submodules(project, project.submodules,
+                               os.path.join(self.topdir, project.path))
 
         # Print performance statistics.
         if take_stats:

--- a/src/west/manifest-schema.yml
+++ b/src/west/manifest-schema.yml
@@ -95,6 +95,21 @@ mapping:
           path:
             required: false
             type: str
+          # Submodules to checkout within the project
+          submodules:
+            required: false
+            type: seq
+            sequence:
+              - type: map
+                mapping:
+                  # Submodule's unique name.
+                  name:
+                    required: true
+                    type: str
+                  # Path to check out, relative to the project's root.
+                  path:
+                    required: true
+                    type: str
           # Limits the clone depth of the project if given.
           clone-depth:
             required: false

--- a/src/west/manifest.py
+++ b/src/west/manifest.py
@@ -66,6 +66,9 @@ SCHEMA_VERSION = '0.8'
 # though it's just a str in each individual file right now.
 WestCommandsType = Union[str, List[str]]
 
+# Type for the submodules value passed through the manifest file.
+SubmodulesType = List[Dict]
+
 # Type for the importer callback passed to the manifest constructor.
 # (ImportedContentType is just an alias for what it gives back.)
 ImportedContentType = Optional[Union[str, List[str]]]
@@ -514,6 +517,7 @@ class Project:
     def __init__(self, name: str, url: str,
                  revision: Optional[str] = None,
                  path: Optional[PathType] = None,
+                 submodules: Optional[SubmodulesType] = None,
                  clone_depth: Optional[int] = None,
                  west_commands: Optional[WestCommandsType] = None,
                  topdir: Optional[PathType] = None,
@@ -527,6 +531,7 @@ class Project:
         :param url: fetch URL
         :param revision: fetch revision
         :param path: path (relative to topdir), or None for *name*
+        :param submodules: submodules to pull within the project
         :param clone_depth: depth to use for initial clone
         :param west_commands: path to a west commands specification YAML
             file in the project, relative to its base directory,
@@ -538,6 +543,7 @@ class Project:
 
         self.name = name
         self.url = url
+        self.submodules = submodules
         self.revision = revision or _DEFAULT_REV
         self.clone_depth = clone_depth
         self.path = os.fspath(path or name)
@@ -843,6 +849,7 @@ class ManifestProject(Project):
 
         # Pretending that this is a Project, even though it's not (#327)
         self.url: str = ''
+        self.submodules = None
         self.revision: str = 'HEAD'
         self.clone_depth: Optional[int] = None
         # The following type: ignore is necessary since every Project
@@ -1651,7 +1658,8 @@ class Manifest:
         path = (ctx.path_prefix / pfx / pd.get('path', name)).as_posix()
 
         ret = Project(name, url, pd.get('revision', defaults.revision),
-                      path, clone_depth=pd.get('clone-depth'),
+                      path, submodules=pd.get('submodules'),
+                      clone_depth=pd.get('clone-depth'),
                       west_commands=pd.get('west-commands'),
                       topdir=self.topdir, remote_name=remote)
 


### PR DESCRIPTION
The submodules was added to the manifest in order to enable
updating projects submodules when performing update operation.

Fixes: #365

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>